### PR TITLE
add dependency metadata (closes #3)

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,5 +24,9 @@
     "issues": "https://github.com/Ladysnake/Nomad-Books/issues",
     "discord": "ladysnake.glitch.me/discord"
   },
-  "license": "CC-BY-NC-SA 4.0"
+  "license": "CC-BY-NC-SA 4.0",
+
+  "depends": {
+    "fabric": "*"
+  }
 }


### PR DESCRIPTION
this will make loom crash with a proper error message if Fabric API is not found, instead of a ClassNotFoundError (fix for #3).

**Note**: you may want to only require specific api modules in the future, depending on what parts of the API you access.