### PR TITLE
0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
 # Nomad Books - Changelog
 
+### Nomad Books 0.5.3 - 1.16.1
+- Removed block breaking effects when reclaiming a camp
+- Fixed an issue where the server would crash upon a player retrieving their camp
+
 ### Nomad Books 0.5.2 - 1.16.1
 - Changed firefly camp limit render to use custom particles
 - Reintroduced the specific error message when trying to retrieve a camp in a different dimension
 - Teleporting to a camp using ender pearls will now cost one pearl for every 60 blocks instead of one for any distance
-- Fixed an issue where players would get kick from a server upon applying itinerant ink
+- Fixed an issue where players would get kicked from the server upon applying itinerant ink
 - Fixed an issue where some blocks would drop items upon retrieving the camp
 - Fixed an issue where fluids would stay upon retrieving a camp
 - Fixed an issue where teleporting back to a camp in creative mode would consume an ender pearl
 - Fixed an issue where beds would still be counted as occupied when redeploying a camp
 
 ### Nomad Books 0.5.1 - 1.16.1
-- Fixed an issue where players would get instantly kicked from a server upon joining
+- Fixed an issue where players would get instantly kicked from the server upon joining
 
 ### Nomad Books 0.5 - 1.16.1
 - Updated to Minecraft 1.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Nomad Books 0.5.5 - 1.16.2
 - Fixed an issue where ghost camps would visually stay for other clients when retrieving a camp
-- Added an additional nomad book to the creative inventory that has all upgrades and a width and height of 15 by default
+- Added an additional nomad book to the creative inventory (master nomad book) that has all upgrades and a width and height of 15 by default
 - Updated to Minecraft 1.16.2
 
 ### Nomad Books 0.5.4 - 1.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Nomad Books 0.5.5 - 1.16.2
 - Fixed an issue where ghost camps would visually stay for other clients when retrieving a camp
-- Added an additional nomad book to the creative inventory (master nomad book) that has all upgrades and a width and height of 15 by default
+- Fixed an issue where furnaces would drop experience despite keeping it when redeployed
+- Added a nomad book to the creative inventory (master nomad book) that has all upgrades and a width and height of 15 by default
 - Updated to Minecraft 1.16.2
 
 ### Nomad Books 0.5.4 - 1.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Nomad Books - Changelog
 
+### Nomad Books 0.5.4 - 1.16.1
+- Fixed an issue where double horizontal blocks such as beds would drop as items
+
 ### Nomad Books 0.5.3 - 1.16.1
 - Removed block breaking effects when reclaiming a camp
 - Fixed an issue where the server would crash upon a player retrieving their camp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nomad Books - Changelog
 
+### Nomad Books 0.5.5 - 1.16.2
+- Fixed an issue where ghost camps would visually stay for other clients when retrieving a camp
+- Added an additional nomad book to the creative inventory that has all upgrades and a width and height of 15 by default
+- Updated to Minecraft 1.16.2
+
 ### Nomad Books 0.5.4 - 1.16.1
 - Fixed an issue where double horizontal blocks such as beds would drop as items
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.8.9+build.203
 fabric_version=0.14.1+build.372-1.16
 
 # Mod Properties
-mod_version = 0.5.2
+mod_version = 0.5.3
 maven_group = io.github.ladysnake
 archives_base_name = nomadbooks
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-minecraft_version=1.16.1
-yarn_mappings=1.16.1+build.20
-loader_version=0.8.9+build.203
+minecraft_version=1.16.2
+yarn_mappings=1.16.2+build.6
+loader_version=0.9.1+build.205
 
 #Fabric api
-fabric_version=0.14.1+build.372-1.16
+fabric_version=0.17.2+build.396-1.16
 
 # Mod Properties
-mod_version = 0.5.4
+mod_version = 0.5.5
 maven_group = io.github.ladysnake
 archives_base_name = nomadbooks
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.8.9+build.203
 fabric_version=0.14.1+build.372-1.16
 
 # Mod Properties
-mod_version = 0.5.3
+mod_version = 0.5.4
 maven_group = io.github.ladysnake
 archives_base_name = nomadbooks
 

--- a/src/main/java/ladysnake/nomadbooks/NomadBooks.java
+++ b/src/main/java/ladysnake/nomadbooks/NomadBooks.java
@@ -44,15 +44,13 @@ public class NomadBooks implements ModInitializer {
     public static Item NETHER_NOMAD_BOOK;
     public static Item AQUATIC_MEMBRANE_PAGE;
     public static Item MYCELIUM_PAGE;
-//    public static Item END_PAGE;
+    public static Item CREATIVE_NOMAD_BOOK;
 
     public static Block MEMBRANE;
     public static Block NOMAD_MUSHROOM_BLOCK;
     public static Block NOMAD_MUSHROOM_STEM;
-//    public static Block TELEPORTER;
 
     public static SpecialRecipeSerializer<NomadBookCraftRecipe> CRAFT_NOMAD_BOOK;
-//    public static SpecialRecipeSerializer<NomadPageCraftRecipe> CRAFT_NOMAD_PAGE;     // obsolete
     public static SpecialRecipeSerializer<NomadBookHeightUpgradeRecipe> UPGRADE_HEIGHT_NOMAD_BOOK;
     public static SpecialRecipeSerializer<NomadBookDismantleRecipe> DISMANTLE_NOMAD_BOOK;
     public static SpecialRecipeSerializer<NomadBookUpgradeRecipe> UPGRADE_NOMAD_BOOK;
@@ -67,7 +65,7 @@ public class NomadBooks implements ModInitializer {
         NETHER_NOMAD_BOOK = registerItem(new NomadBookItem((new Item.Settings()).maxCount(1).group(ItemGroup.MISC).rarity(Rarity.RARE).fireproof()), "nether_nomad_book");
         AQUATIC_MEMBRANE_PAGE = registerItem(new BookUpgradeItem((new Item.Settings()).maxCount(1).group(ItemGroup.MISC).rarity(Rarity.UNCOMMON), "aquatic_membrane"), "aquatic_membrane_page");
         MYCELIUM_PAGE = registerItem(new BookUpgradeItem((new Item.Settings()).maxCount(1).group(ItemGroup.MISC).rarity(Rarity.UNCOMMON), "fungi_support"), "mycelium_page");
-//        END_PAGE = registerItem(new BookUpgradeItem((new Item.Settings()).maxCount(1).group(ItemGroup.MISC).rarity(Rarity.UNCOMMON), "end"), "end_page");
+        CREATIVE_NOMAD_BOOK = registerItem(new NomadBookItem((new Item.Settings()).maxCount(1).group(ItemGroup.MISC).rarity(Rarity.RARE).fireproof()), "master_nomad_book");
 
         // add loot to dungeons, mineshafts, jungle temples, and stronghold libraries chests loot tables
         LootTableLoadingCallback.EVENT.register((resourceManager, lootManager, id, supplier, setter) -> {
@@ -142,10 +140,8 @@ public class NomadBooks implements ModInitializer {
         MEMBRANE = Registry.register(Registry.BLOCK, MODID + ":membrane", new MembraneBlock(FabricBlockSettings.of(Material.SOLID_ORGANIC).strength(0.6f, 0f).nonOpaque().sounds(BlockSoundGroup.HONEY).noCollision().build()));
         NOMAD_MUSHROOM_BLOCK = Registry.register(Registry.BLOCK, MODID + ":nomad_mushroom_block", new NomadMushroomBlock(FabricBlockSettings.of(Material.WOOD, MaterialColor.PURPLE).strength(0.6F, 0).sounds(BlockSoundGroup.WOOD).build()));
         NOMAD_MUSHROOM_STEM = Registry.register(Registry.BLOCK, MODID + ":nomad_mushroom_stem", new NomadMushroomStemBlock(FabricBlockSettings.of(Material.WOOD, MaterialColor.WEB).strength(0.6F, 0).sounds(BlockSoundGroup.WOOD).build()));
-//        TELEPORTER = Registry.register(Registry.BLOCK, MODID + ":teleporter", new TeleporterBlock(FabricBlockSettings.of(Material.STONE, MaterialColor.GREEN).sounds(BlockSoundGroup.GLASS).lightLevel(1).build()));
 
         NomadBookCraftRecipe.initCraftResult();
-//        CRAFT_NOMAD_PAGE = Registry.register(Registry.RECIPE_SERIALIZER, new Identifier(MODID, "crafting_special_nomadpagecraft"), new SpecialRecipeSerializer<>(NomadPageCraftRecipe::new));
         CRAFT_NOMAD_BOOK = Registry.register(Registry.RECIPE_SERIALIZER, new Identifier(MODID, "crafting_special_nomadbookcraft"), new SpecialRecipeSerializer<>(NomadBookCraftRecipe::new));
         UPGRADE_HEIGHT_NOMAD_BOOK = Registry.register(Registry.RECIPE_SERIALIZER, new Identifier(MODID, "crafting_special_nomadbookupgradeheight"), new SpecialRecipeSerializer<>(NomadBookHeightUpgradeRecipe::new));
         DISMANTLE_NOMAD_BOOK = Registry.register(Registry.RECIPE_SERIALIZER, new Identifier(MODID, "crafting_special_nomadbookdismantle"), new SpecialRecipeSerializer<>(NomadBookDismantleRecipe::new));

--- a/src/main/java/ladysnake/nomadbooks/common/item/NomadBookItem.java
+++ b/src/main/java/ladysnake/nomadbooks/common/item/NomadBookItem.java
@@ -279,6 +279,16 @@ public class NomadBookItem extends Item {
                     itemStack.getOrCreateTag().putFloat(NomadBooks.MODID + ":deployed", 0F);
                 }
 
+                // replace everything with barriers so no surface dependant blocks drop
+                for (int x = 0; x < width; x++) {
+                    for (int z = 0; z < width; z++) {
+                        for (int y = 0; y < height; y++) {
+                            BlockPos p = pos.add(new BlockPos(x, y, z));
+                            world.setBlockState(p, Blocks.BARRIER.getDefaultState());
+                        }
+                    }
+                }
+
                 // remove blocks
                 for (int x = 0; x < width; x++) {
                     for (int z = 0; z < width; z++) {
@@ -300,7 +310,7 @@ public class NomadBookItem extends Item {
                                         !((x == -1 && z == -1) || (x == -1 && z == width) || (x == width && z == -1) || (x == width && z == width)
                                                 || (y == height && x == -1) || (y == height && x == width) || (y == height && z == -1) || (y == height && z == width)) &&
                                         (x == -1 || x == width || y == -1 || y == height || z == -1 || z == width)) {
-                                    world.breakBlock(p, true);
+                                    removeBlock(world, p);
                                 }
                             }
                         }
@@ -327,17 +337,6 @@ public class NomadBookItem extends Item {
                             }
                         }
                     }
-                }
-
-                // remove blocks dropped by accident
-                if (!world.isClient()) {
-                    BlockPos p2 = pos.add(new BlockPos(width, height, width));
-                    List<ItemEntity> itemEntities = world.getEntities(EntityType.ITEM, new Box(pos.getX(), pos.getY(), pos.getZ(), p2.getX(), p2.getY(), p2.getZ()), itemEntity -> true);
-                    itemEntities.forEach(itemEntity -> {
-                        if (itemEntity.getAge() < 1) {
-                            itemEntity.remove();
-                        }
-                    });
                 }
 
                 // remove boundaries display
@@ -423,7 +422,7 @@ public class NomadBookItem extends Item {
     }
 
     public void removeBlock(World world, BlockPos blockPos) {
-        world.breakBlock(blockPos, false);
+//        world.breakBlock(blockPos, false);
         world.setBlockState(blockPos, Blocks.AIR.getDefaultState());
     }
 }

--- a/src/main/java/ladysnake/nomadbooks/common/item/NomadBookItem.java
+++ b/src/main/java/ladysnake/nomadbooks/common/item/NomadBookItem.java
@@ -279,16 +279,6 @@ public class NomadBookItem extends Item {
                     itemStack.getOrCreateTag().putFloat(NomadBooks.MODID + ":deployed", 0F);
                 }
 
-                // replace everything with barriers so no surface dependant blocks drop
-                for (int x = 0; x < width; x++) {
-                    for (int z = 0; z < width; z++) {
-                        for (int y = 0; y < height; y++) {
-                            BlockPos p = pos.add(new BlockPos(x, y, z));
-                            world.setBlockState(p, Blocks.BARRIER.getDefaultState());
-                        }
-                    }
-                }
-
                 // remove blocks
                 for (int x = 0; x < width; x++) {
                     for (int z = 0; z < width; z++) {
@@ -422,7 +412,6 @@ public class NomadBookItem extends Item {
     }
 
     public void removeBlock(World world, BlockPos blockPos) {
-//        world.breakBlock(blockPos, false);
-        world.setBlockState(blockPos, Blocks.AIR.getDefaultState());
+        world.setBlockState(blockPos, Blocks.AIR.getDefaultState(), 0b0010000);
     }
 }

--- a/src/main/java/ladysnake/nomadbooks/common/item/NomadBookItem.java
+++ b/src/main/java/ladysnake/nomadbooks/common/item/NomadBookItem.java
@@ -4,20 +4,11 @@ import ladysnake.nomadbooks.NomadBooks;
 import ladysnake.nomadbooks.common.block.NomadMushroomBlock;
 import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.block.*;
-import net.minecraft.block.entity.BedBlockEntity;
 import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.client.item.TooltipContext;
-import net.minecraft.datafixer.NbtOps;
-import net.minecraft.entity.EntityType;
-import net.minecraft.entity.ItemEntity;
-import net.minecraft.entity.passive.VillagerEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.*;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.NbtHelper;
-import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.*;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
@@ -29,7 +20,6 @@ import net.minecraft.text.TranslatableText;
 import net.minecraft.util.*;
 import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Box;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.World;
@@ -284,7 +274,27 @@ public class NomadBookItem extends Item {
                     for (int z = 0; z < width; z++) {
                         for (int y = 0; y < height; y++) {
                             BlockPos p = pos.add(new BlockPos(x, y, z));
-                            removeBlock(world, p);
+                            world.setBlockState(p, Blocks.AIR.getDefaultState(), 0b0010000);
+                        }
+                    }
+                }
+
+                // update neighbors
+                // now I know, this is against the geneva convention, but updateNeighbors doesn't work, so fuck it
+                // only problem is I still have some fucking lighting bugs when reclaiming a camp, but I give up
+                for (int x = 0; x < width; x++) {
+                    for (int z = 0; z < width; z++) {
+                        for (int y = 0; y < height; y++) {
+                            BlockPos p = pos.add(new BlockPos(x, y, z));
+                            world.setBlockState(p, Blocks.BEDROCK.getDefaultState());
+                        }
+                    }
+                }
+                for (int x = 0; x < width; x++) {
+                    for (int z = 0; z < width; z++) {
+                        for (int y = 0; y < height; y++) {
+                            BlockPos p = pos.add(new BlockPos(x, y, z));
+                            world.setBlockState(p, Blocks.AIR.getDefaultState());
                         }
                     }
                 }
@@ -412,6 +422,6 @@ public class NomadBookItem extends Item {
     }
 
     public void removeBlock(World world, BlockPos blockPos) {
-        world.setBlockState(blockPos, Blocks.AIR.getDefaultState(), 0b0010000);
+        world.setBlockState(blockPos, Blocks.AIR.getDefaultState());
     }
 }

--- a/src/main/java/ladysnake/nomadbooks/common/item/NomadBookItem.java
+++ b/src/main/java/ladysnake/nomadbooks/common/item/NomadBookItem.java
@@ -392,7 +392,17 @@ public class NomadBookItem extends Item {
     public void appendStacks(ItemGroup group, DefaultedList<ItemStack> stacks) {
         super.appendStacks(group, stacks);
         stacks.forEach(itemStack -> {
-            if (itemStack.getItem() instanceof NomadBookItem) {
+            if (itemStack.getItem() == NomadBooks.CREATIVE_NOMAD_BOOK) {
+                CompoundTag tags = itemStack.getOrCreateSubTag(NomadBooks.MODID);
+                tags.putInt("Height", 15);
+                tags.putInt("Width", 15);
+                tags.putString("Structure", netherDefaultStructurePath);
+                // upgrades
+                ListTag upgradeList = new ListTag();
+                upgradeList.add(StringTag.of("aquatic_membrane"));
+                upgradeList.add(StringTag.of("fungi_support"));
+                tags.put("Upgrades", upgradeList);
+            } else if (itemStack.getItem() instanceof NomadBookItem) {
                 CompoundTag tags = itemStack.getOrCreateSubTag(NomadBooks.MODID);
                 tags.putInt("Height", 3);
                 tags.putInt("Width", 7);

--- a/src/main/java/ladysnake/nomadbooks/common/item/NomadBookItem.java
+++ b/src/main/java/ladysnake/nomadbooks/common/item/NomadBookItem.java
@@ -259,8 +259,7 @@ public class NomadBookItem extends Item {
                         for (int z = 0; z < width; z++) {
                             for (int y = 0; y < height; y++) {
                                 BlockPos p = pos.add(new BlockPos(x, y, z));
-                                BlockEntity blockEntity = serverWorld.getBlockEntity(p);
-                                Clearable.clear(blockEntity);
+                                world.removeBlockEntity(p);
                             }
                         }
                     }

--- a/src/main/java/ladysnake/nomadbooks/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/ladysnake/nomadbooks/mixin/ClientPlayerEntityMixin.java
@@ -10,7 +10,6 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtHelper;
-import net.minecraft.particle.ParticleTypes;
 import net.minecraft.util.math.BlockPos;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/ladysnake/nomadbooks/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/ladysnake/nomadbooks/mixin/ServerPlayerEntityMixin.java
@@ -18,7 +18,9 @@ import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.BuiltinRegistries;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -31,8 +33,8 @@ import static net.minecraft.text.Style.EMPTY;
 public abstract class ServerPlayerEntityMixin extends PlayerEntity {
     @Shadow public abstract void sendMessage(Text message, boolean bl);
 
-    public ServerPlayerEntityMixin(MinecraftServer server, ServerWorld world, GameProfile profile, ServerPlayerInteractionManager interactionManager) {
-        super(world, world.getSpawnPos(), profile);
+    public ServerPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile profile) {
+        super(world, pos, yaw, profile);
     }
 
     @Inject(at = @At(value = "FIELD", target = "Lnet/minecraft/advancement/criterion/Criteria;LOCATION:Lnet/minecraft/advancement/criterion/LocationArrivalCriterion;"), method = "playerTick")
@@ -44,8 +46,8 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity {
                 // if inventory has an inked nomad book
                 if (tags.getBoolean("Inked")) {
                     ListTag visitedBiomes = tags.getList("VisitedBiomes", NbtType.STRING);
-                    if (Registry.BIOME.getId(this.world.getBiome(this.getBlockPos())) != null) {
-                        StringTag biome = StringTag.of(Registry.BIOME.getId(this.world.getBiome(this.getBlockPos())).toString());
+                    if (BuiltinRegistries.BIOME.getId(this.world.getBiome(this.getBlockPos())) != null) {
+                        StringTag biome = StringTag.of(BuiltinRegistries.BIOME.getId(this.world.getBiome(this.getBlockPos())).toString());
                         if (!visitedBiomes.contains(biome)) {
                             // if not the first biome (just crafted), increment progress
                             if (!visitedBiomes.isEmpty()) {


### PR DESCRIPTION
### Nomad Books 0.5.5 - 1.16.2
- Fixed an issue where ghost camps would visually stay for other clients when retrieving a camp
- Fixed an issue where furnaces would drop experience despite keeping it when redeployed
- Added a nomad book to the creative inventory (master nomad book) that has all upgrades and a width and height of 15 by default
- Updated to Minecraft 1.16.2